### PR TITLE
Group answer IDs in answer store for better filtering efficiency

### DIFF
--- a/tests/app/data_model/test_questionnaire_store.py
+++ b/tests/app/data_model/test_questionnaire_store.py
@@ -12,7 +12,7 @@ def get_basic_input():
             'test': True
         },
         'ANSWERS': [{
-            'answer-id': 'test',
+            'answer_id': 'test',
             'value': 'test',
         }],
         'COMPLETED_BLOCKS': [

--- a/tests/app/questionnaire/test_navigation.py
+++ b/tests/app/questionnaire/test_navigation.py
@@ -651,6 +651,7 @@ class TestNavigation(AppContextTestCase):
 
         answer_store.update(change_answer)
 
+        navigation = _create_navigation(schema, answer_store, metadata, completed_blocks, [])
         user_navigation = navigation.build_navigation('property-details', 0)
 
         link_names = [d['link_name'] for d in user_navigation]


### PR DESCRIPTION
### What is the context of this PR?
This PR adds a dict mapping of answer ID to a list of answers to the `AnswerStore` object. This makes calls to `AnswerStore.filter()` more efficient, especially with a large number of answers.

This reduced the CPU time by around 10ms for both GETs and POSTs during profiling. At this point the answer store was relatively small and a greater improvement would be expected for requests later in a large survey or for ones with a large number of repeating groups. 

### How to review 
Check code makes sense and there is no potential for the new `answer_map` object to get out of sync with the main list of answers.

Manually test application.

### Checklist

* [ ] New static content marked up for translation
* [ ] Newly defined schema content included in eq-translations repo
