### PR TITLE
Workaround pipenv issue with pip 18.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,8 @@ env:
     - AWS_DEFAULT_REGION=eu-west-1
     - AWS_ACCESS_KEY_ID=dummy-access-key
     - AWS_SECRET_ACCESS_KEY=dummy-secret-key
+
+    - PIP_SHIMS_BASE_MODULE=pipenv.patched.notpip
     # Codacy
     - secure: q3hyZhRj24C5sT7T0ViTDCwhT8eVjpanTf6BkPPBI43/6NBJeF1vi4/LkfJMQa0qwYibu5zB8jtkk2VsqGRMGvj9fMufOKXGqebOsPYWUJl1MZM3t7OZS57xF9wBUenZwx1oyb/VPrFB56ctGny1XEbF4l47NmbKWD1iMWG1f3Y6PCJ7o8o62v0irmfbdYFTsWjipCQlCrKZm+KVWZD25egIDJMDpq9e0nYNoSW+5fMXDGOtV20/U/rcmW5Lfn06ppJ0C4CaKHuM+MzZtZJwtiCI2TqF0ihQl7ry7YgpqEZLPHQYQ5npIpecxP1f/6ebcAPdKKkJ2Ccutrv/7IFlJo7rWLTB7mzJ4ep11HCdo3mL+JREp1HUJLeEngXFC3lKRXPHKukUxe4Lkz1/g6kdwCUZxajGTwML84FHmqoZxKGMKhMN+0n6rO8wEUR32q4+JbO5z/oQGhtjQZkogq8vWY6+/aq328hsbmy72s23AiX+BQUHqk2QFs3T9FQiqwn4OqqX4JKzmHs838LT+dUTFgH+mWo0lalxa3Pr7cJAwhn97VSnIdU9JTC8RyPWbAHkah78PXlL9guHI1nzQTjTcMm/yTlmtE2NxTSY+ZGIV+O5pcJm3HkAjZvNi/0jjDWwBHs/rZgj1t7Eoueh8dPTSZ12LmqKuBpvkrzLKcs2zt4=
 before_install:
@@ -37,8 +39,7 @@ before_install:
     - pyenv install --skip-existing
     - pyenv rehash
     - pyenv global $(cat .python-version)
-    - pip install -U pip pipenv wheel
-    - pipenv run pip install pip==18.0
+    - pip install -U pip==18.0 pipenv wheel
     - pipenv install --dev --deploy
     - pipenv check -i '36333 '
 cache:


### PR DESCRIPTION
### What is the context of this PR?
Workaround for an issue with pip 18.1 being incompatible with some dependency of pipenv.

### How to review 
Does build pass?

### Checklist

* [ ] New static content marked up for translation
* [ ] Newly defined schema content included in eq-translations repo
