### PR TITLE
Ignore 'W504 line break after binary operator' and some other linting

### DIFF
--- a/app/helpers/template_helper.py
+++ b/app/helpers/template_helper.py
@@ -28,7 +28,7 @@ def with_session_timeout(func):
             *args,
             session_timeout=session_timeout,
             session_timeout_prompt=session_timeout_prompt,
-            **kwargs
+            **kwargs,
         )
 
     return session_wrapper
@@ -87,5 +87,5 @@ def render_template(template, **kwargs):
         template,
         survey_title=TemplateRenderer.safe_content(g.schema.json['title']),
         survey_id=g.schema.json['survey_id'],
-        **kwargs
+        **kwargs,
     )

--- a/app/views/questionnaire.py
+++ b/app/views/questionnaire.py
@@ -737,7 +737,7 @@ def _render_template(context, current_location, template, front_end_navigation, 
         previous_location=previous_url,
         page_title=page_title,
         metadata=kwargs.pop('metadata_context'),  # `metadata_context` is used as `metadata` in the jinja templates
-        **kwargs
+        **kwargs,
     )
 
 

--- a/scripts/run_lint.sh
+++ b/scripts/run_lint.sh
@@ -18,7 +18,7 @@ function display_result {
   fi
 }
 
-flake8 --max-complexity 10 --count
+flake8 --ignore=W504 --max-complexity 10 --count
 display_result $? 1 "Flake 8 code style check"
 
 pylint --reports=n --output-format=colorized --rcfile=.pylintrc -j 0 ./app ./tests


### PR DESCRIPTION
### What is the context of this PR?
Linting now failing with "W504 line break after binary operator".

I avoided fixing the errors as it'd create an unnecessary divergence from the upstream project.

### How to review 
...

### Checklist

* [ ] New static content marked up for translation
* [ ] Newly defined schema content included in eq-translations repo
